### PR TITLE
feat:  basic and custom regions

### DIFF
--- a/cmd/hop/cli/start.go
+++ b/cmd/hop/cli/start.go
@@ -23,6 +23,7 @@ var startArgs struct {
 	filToken     string
 	filTokenType string
 	privKeyPath  string
+	regions      string
 }
 
 var startCmd = &ffcli.Command{
@@ -48,6 +49,7 @@ The 'hop start' command starts an IPFS daemon service.
 		fs.StringVar(&startArgs.filToken, "fil-token", "", "token to authorize filecoin api access")
 		fs.StringVar(&startArgs.privKeyPath, "privkey", "", "path to private key to use by default")
 		fs.StringVar(&startArgs.filTokenType, "fil-token-type", "Bearer", "auth token type")
+		fs.StringVar(&startArgs.regions, "regions", "Global", "provider regions separated by commas")
 
 		return fs
 	})(),
@@ -107,6 +109,7 @@ func runStart(ctx context.Context, args []string) error {
 		FilEndpoint:    startArgs.filEndpoint,
 		FilToken:       filToken,
 		PrivKey:        privKey,
+		Regions:        strings.Split(startArgs.regions, ","),
 	}
 
 	err = node.Run(ctx, opts)

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -48,6 +48,7 @@ func TestExchangeDirect(t *testing.T) {
 					GraphSync:  n.Gs,
 					RepoPath:   n.DTTmpDir,
 					Keystore:   keystore.NewMemKeystore(),
+					Regions:    []supply.Region{supply.RegionWithName("Global")},
 				}
 
 				exch, err := NewExchange(bgCtx, settings)

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -48,7 +48,7 @@ func TestExchangeDirect(t *testing.T) {
 					GraphSync:  n.Gs,
 					RepoPath:   n.DTTmpDir,
 					Keystore:   keystore.NewMemKeystore(),
-					Regions:    []supply.Region{supply.RegionWithName("Global")},
+					Regions:    []supply.Region{supply.Regions["Global"]},
 				}
 
 				exch, err := NewExchange(bgCtx, settings)

--- a/node/hopn.go
+++ b/node/hopn.go
@@ -167,7 +167,7 @@ func New(ctx context.Context, opts Options) (*node, error) {
 	// Convert region names to region structs
 	var regions []supply.Region
 	for _, rstring := range opts.Regions {
-		if r := supply.RegionWithName(rstring); r.Name != "" {
+		if r := supply.Regions[rstring]; r.Name != "" {
 			regions = append(regions, r)
 			continue
 		}

--- a/node/hopn.go
+++ b/node/hopn.go
@@ -80,6 +80,9 @@ type Options struct {
 	FilToken string
 	// PrivKey is a hex encoded private key to use for default address
 	PrivKey string
+	// Regions is a list of regions a provider chooses to support.
+	// Nothing prevents providers from participating in regions outside of their geographic location however they may get less deals since the latency is likely to be higher
+	Regions []string
 }
 
 type node struct {
@@ -161,6 +164,20 @@ func New(ctx context.Context, opts Options) (*node, error) {
 		storeutil.StorerForBlockstore(nd.bs),
 	)
 
+	// Convert region names to region structs
+	var regions []supply.Region
+	for _, rstring := range opts.Regions {
+		if r := supply.RegionWithName(rstring); r.Name != "" {
+			regions = append(regions, r)
+			continue
+		}
+		// We also support custom regions if users want their own provider subnet
+		regions = append(regions, supply.Region{
+			Name: rstring,
+			Code: supply.CustomRegion,
+		})
+	}
+
 	settings := hop.Settings{
 		Datastore:  nd.ds,
 		Blockstore: nd.bs,
@@ -174,6 +191,7 @@ func New(ctx context.Context, opts Options) (*node, error) {
 		FilecoinRPCHeader: http.Header{
 			"Authorization": []string{opts.FilToken},
 		},
+		Regions: regions,
 	}
 
 	nd.exch, err = hop.NewExchange(ctx, settings)
@@ -183,6 +201,7 @@ func New(ctx context.Context, opts Options) (*node, error) {
 	if opts.PrivKey != "" {
 		nd.importAddress(opts.PrivKey)
 	}
+	// start connecting with peers
 	go nd.bootstrap(ctx, opts.BootstrapPeers)
 
 	return nd, nil

--- a/node/server.go
+++ b/node/server.go
@@ -243,7 +243,7 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("node.New: %v", err)
 	}
 
-	log.Info().Interface("addrs", nd.host.Addrs()).Msg("Node started libp2p")
+	log.Info().Strs("regions", opts.Regions).Msg("node is running")
 
 	server := &server{
 		node: nd,

--- a/options.go
+++ b/options.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/libp2p/go-libp2p-core/host"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/myelnet/go-hop-exchange/supply"
 )
 
 // TODO: We should be able to customize these in the options
@@ -56,6 +57,8 @@ type Settings struct {
 	RepoPath            string
 	FilecoinRPCEndpoint string
 	FilecoinRPCHeader   http.Header
+	// Probably temporary as we want Regions to be more dynamic eventually
+	Regions []supply.Region
 }
 
 // NewDataTransfer packages together all the things needed for a new manager to work

--- a/supply/network.go
+++ b/supply/network.go
@@ -17,11 +17,16 @@ import (
 
 //go:generate cbor-gen-for AddRequest
 
-// AddRequestProtocolID labels our network for announcing new content to the network
-const AddRequestProtocolID = protocol.ID("/myel/hop/supply/add/1.0")
+// AddRequestProtocol labels our network for announcing new content to the network
+const AddRequestProtocol = "/myel/hop/supply/add/1.0"
 
-// QueryProtocolID labels our supply network protocol
-const QueryProtocolID = protocol.ID("/myel/hop/supply/query/1.0")
+func protoRegions(proto string, regions []Region) []protocol.ID {
+	var pls []protocol.ID
+	for _, r := range regions {
+		pls = append(pls, protocol.ID(fmt.Sprintf("%s/%s", proto, r.Name)))
+	}
+	return pls
+}
 
 // AddRequest describes the new content to anounce
 type AddRequest struct {
@@ -43,13 +48,10 @@ type Network struct {
 }
 
 // NewNetwork creates a new Network instance
-func NewNetwork(h host.Host) *Network {
+func NewNetwork(h host.Host, regions []Region) *Network {
 	sn := &Network{
-		host: h,
-		protocols: []protocol.ID{
-			AddRequestProtocolID,
-			QueryProtocolID,
-		},
+		host:      h,
+		protocols: protoRegions(AddRequestProtocol, regions),
 	}
 	return sn
 }

--- a/supply/network_test.go
+++ b/supply/network_test.go
@@ -38,8 +38,15 @@ func TestAddRequestStream(t *testing.T) {
 	err := mn.LinkAll()
 	require.NoError(t, err)
 
-	net1 := NewNetwork(n1.Host)
-	net2 := NewNetwork(n2.Host)
+	regions := []Region{
+		{
+			Name: "Test",
+			Code: CustomRegion,
+		},
+	}
+
+	net1 := NewNetwork(n1.Host, regions)
+	net2 := NewNetwork(n2.Host, regions)
 
 	payload := blockGenerator.Next().Cid()
 	done := make(chan bool)

--- a/supply/regions.go
+++ b/supply/regions.go
@@ -1,7 +1,6 @@
 package supply
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -66,46 +65,13 @@ var (
 	}
 )
 
-var regionsByName = map[string]Region{}
-var regionsByCode = map[RegionCode]Region{}
-
-// AddRegion registers a new region
-func AddRegion(r Region) error {
-	if _, ok := regionsByName[r.Name]; ok {
-		return fmt.Errorf("region by the name %s already exists", r.Name)
-	}
-
-	if reg, ok := regionsByCode[r.Code]; ok {
-		return fmt.Errorf("region code %d already taken by %q", r.Code, reg.Name)
-	}
-
-	regionsByName[r.Name] = r
-	regionsByCode[r.Code] = r
-	return nil
-}
-
-// RegionWithName returns a Region for a given name
-func RegionWithName(n string) Region {
-	return regionsByName[n]
-}
-
-// RegionWithCode returns a Region for a given RegionCode
-func RegionWithCode(c RegionCode) Region {
-	return regionsByCode[c]
-}
-
-func init() {
-	for _, r := range []Region{
-		global,
-		asia,
-		africa,
-		southAmerica,
-		northAmerica,
-		europe,
-		oceania,
-	} {
-		if err := AddRegion(r); err != nil {
-			panic(err)
-		}
-	}
+// Regions is a list of preset regions
+var Regions = map[string]Region{
+	"Global":       global,
+	"Asia":         asia,
+	"Africa":       africa,
+	"SouthAmerica": southAmerica,
+	"NorthAmerica": northAmerica,
+	"Europe":       europe,
+	"Oceania":      oceania,
 }

--- a/supply/regions.go
+++ b/supply/regions.go
@@ -1,0 +1,111 @@
+package supply
+
+import (
+	"fmt"
+	"math"
+)
+
+// Regions: This is very experimental and needs more iterations to be stable
+
+// RegionCode defines a subnetwork code
+type RegionCode uint64
+
+const (
+	// GlobalRegion region is a free global network for anyone to try the network
+	GlobalRegion RegionCode = iota
+	// AsiaRegion is a specific region to connect caches in the Asian area
+	AsiaRegion
+	// AfricaRegion is a specific region in the African geographic area
+	AfricaRegion
+	// SouthAmericaRegion is a specific region
+	SouthAmericaRegion
+	// NorthAmericaRegion is a specific region to connect caches in the North American area
+	NorthAmericaRegion
+	// EuropeRegion is a specific region to connect caches in the European area
+	EuropeRegion
+	// OceaniaRegion is a specific region
+	OceaniaRegion
+	// CustomRegion is a user defined region
+	CustomRegion = math.MaxUint64
+)
+
+// Region represents a CDN subnetwork
+type Region struct {
+	Name string
+	Code RegionCode
+}
+
+var (
+	global = Region{
+		Name: "Global",
+		Code: GlobalRegion,
+	}
+	asia = Region{
+		Name: "Asia",
+		Code: AsiaRegion,
+	}
+	africa = Region{
+		Name: "Africa",
+		Code: AfricaRegion,
+	}
+	southAmerica = Region{
+		Name: "SouthAmerica",
+		Code: SouthAmericaRegion,
+	}
+	northAmerica = Region{
+		Name: "NorthAmerica",
+		Code: NorthAmericaRegion,
+	}
+	europe = Region{
+		Name: "Europe",
+		Code: EuropeRegion,
+	}
+	oceania = Region{
+		Name: "Oceania",
+		Code: OceaniaRegion,
+	}
+)
+
+var regionsByName = map[string]Region{}
+var regionsByCode = map[RegionCode]Region{}
+
+// AddRegion registers a new region
+func AddRegion(r Region) error {
+	if _, ok := regionsByName[r.Name]; ok {
+		return fmt.Errorf("region by the name %s already exists", r.Name)
+	}
+
+	if reg, ok := regionsByCode[r.Code]; ok {
+		return fmt.Errorf("region code %d already taken by %q", r.Code, reg.Name)
+	}
+
+	regionsByName[r.Name] = r
+	regionsByCode[r.Code] = r
+	return nil
+}
+
+// RegionWithName returns a Region for a given name
+func RegionWithName(n string) Region {
+	return regionsByName[n]
+}
+
+// RegionWithCode returns a Region for a given RegionCode
+func RegionWithCode(c RegionCode) Region {
+	return regionsByCode[c]
+}
+
+func init() {
+	for _, r := range []Region{
+		global,
+		asia,
+		africa,
+		southAmerica,
+		northAmerica,
+		europe,
+		oceania,
+	} {
+		if err := AddRegion(r); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/supply/supply_test.go
+++ b/supply/supply_test.go
@@ -113,3 +113,92 @@ func TestSendAddRequestNoPeers(t *testing.T) {
 	err := supply.SendAddRequest(rootCid, uint64(len(origBytes)))
 	require.EqualError(t, err, ErrNoPeers.Error())
 }
+
+// The role of this test is to make sure we never dispatch content to unwanted regions
+func TestSendAddRequestDiffRegions(t *testing.T) {
+	bgCtx := context.Background()
+
+	ctx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
+	defer cancel()
+
+	mn := mocknet.New(bgCtx)
+
+	n1 := testutil.NewTestNode(mn, t)
+	n1.SetupDataTransfer(bgCtx, t)
+	require.NoError(t, n1.Dt.RegisterVoucherType(&AddRequest{}, &testutil.FakeDTValidator{}))
+
+	// n1 is our client is adding a file to the store
+	link, origBytes := n1.LoadUnixFSFileToStore(bgCtx, t, "/supply/readme.md")
+	rootCid := link.(cidlink.Link).Cid
+
+	asia := []Region{
+		RegionWithName("Asia"),
+	}
+
+	supply := New(ctx, n1.Host, n1.Dt, asia)
+
+	asiaNodes := make(map[peer.ID]*testutil.TestNode)
+	var asiaSupplies []*Supply
+	// We add a bunch of asian retrieval providers
+	for i := 0; i < 5; i++ {
+		n := testutil.NewTestNode(mn, t)
+		n.SetupDataTransfer(bgCtx, t)
+
+		// Create a supply for each node
+		s := New(ctx, n.Host, n.Dt, asia)
+
+		asiaNodes[n.Host.ID()] = n
+		asiaSupplies = append(asiaSupplies, s)
+	}
+
+	africa := []Region{
+		RegionWithName("Africa"),
+	}
+
+	africaNodes := make(map[peer.ID]*testutil.TestNode)
+	var africaSupplies []*Supply
+	// Add african providers
+	for i := 0; i < 3; i++ {
+		n := testutil.NewTestNode(mn, t)
+		n.SetupDataTransfer(bgCtx, t)
+
+		// Create a supply for each node
+		s := New(ctx, n.Host, n.Dt, africa)
+
+		africaNodes[n.Host.ID()] = n
+		africaSupplies = append(africaSupplies, s)
+	}
+
+	err := mn.LinkAll()
+	require.NoError(t, err)
+
+	err = mn.ConnectAllButSelf()
+	require.NoError(t, err)
+
+	receivers := make(chan peer.ID, 6)
+	done := make(chan error)
+	unsubscribe := supply.SubscribeToEvents(func(event Event) {
+		require.Equal(t, rootCid, event.PayloadCID)
+		receivers <- event.Provider
+		if len(receivers)+1 == cap(receivers) {
+			done <- nil
+		}
+
+	})
+	defer unsubscribe()
+
+	err = supply.SendAddRequest(rootCid, uint64(len(origBytes)))
+	require.NoError(t, err)
+
+	select {
+	case <-ctx.Done():
+		t.Error("requests incomplete")
+	case <-done:
+		pp := supply.providerPeers[rootCid].Peers()
+		require.Equal(t, len(pp), 5)
+		for i := 0; i < len(pp); i++ {
+			asiaNodes[pp[i]].VerifyFileTransferred(ctx, t, rootCid, origBytes)
+		}
+
+	}
+}

--- a/supply/supply_test.go
+++ b/supply/supply_test.go
@@ -28,7 +28,14 @@ func TestSendAddRequest(t *testing.T) {
 	link, origBytes := n1.LoadUnixFSFileToStore(bgCtx, t, "/supply/readme.md")
 	rootCid := link.(cidlink.Link).Cid
 
-	supply := New(ctx, n1.Host, n1.Dt)
+	regions := []Region{
+		{
+			Name: "TestRegion",
+			Code: CustomRegion,
+		},
+	}
+
+	supply := New(ctx, n1.Host, n1.Dt, regions)
 
 	providers := make(map[peer.ID]*testutil.TestNode)
 	var supplies []*Supply
@@ -38,7 +45,7 @@ func TestSendAddRequest(t *testing.T) {
 		n.SetupDataTransfer(bgCtx, t)
 
 		// Create a supply for each node
-		s := New(ctx, n.Host, n.Dt)
+		s := New(ctx, n.Host, n.Dt, regions)
 
 		providers[n.Host.ID()] = n
 		supplies = append(supplies, s)
@@ -94,7 +101,14 @@ func TestSendAddRequestNoPeers(t *testing.T) {
 	link, origBytes := n1.LoadUnixFSFileToStore(bgCtx, t, "/supply/readme.md")
 	rootCid := link.(cidlink.Link).Cid
 
-	supply := New(ctx, n1.Host, n1.Dt)
+	regions := []Region{
+		{
+			Name: "TestRegion",
+			Code: CustomRegion,
+		},
+	}
+
+	supply := New(ctx, n1.Host, n1.Dt, regions)
 
 	err := supply.SendAddRequest(rootCid, uint64(len(origBytes)))
 	require.EqualError(t, err, ErrNoPeers.Error())

--- a/supply/supply_test.go
+++ b/supply/supply_test.go
@@ -62,7 +62,7 @@ func TestSendAddRequest(t *testing.T) {
 	unsubscribe := supply.SubscribeToEvents(func(event Event) {
 		require.Equal(t, rootCid, event.PayloadCID)
 		receivers <- event.Provider
-		if len(receivers)+1 == cap(receivers) {
+		if len(receivers) == cap(receivers) {
 			done <- nil
 		}
 
@@ -132,7 +132,7 @@ func TestSendAddRequestDiffRegions(t *testing.T) {
 	rootCid := link.(cidlink.Link).Cid
 
 	asia := []Region{
-		RegionWithName("Asia"),
+		Regions["Asia"],
 	}
 
 	supply := New(ctx, n1.Host, n1.Dt, asia)
@@ -152,7 +152,7 @@ func TestSendAddRequestDiffRegions(t *testing.T) {
 	}
 
 	africa := []Region{
-		RegionWithName("Africa"),
+		Regions["Africa"],
 	}
 
 	africaNodes := make(map[peer.ID]*testutil.TestNode)
@@ -175,15 +175,14 @@ func TestSendAddRequestDiffRegions(t *testing.T) {
 	err = mn.ConnectAllButSelf()
 	require.NoError(t, err)
 
-	receivers := make(chan peer.ID, 6)
+	receivers := make(chan peer.ID, 4)
 	done := make(chan error)
 	unsubscribe := supply.SubscribeToEvents(func(event Event) {
 		require.Equal(t, rootCid, event.PayloadCID)
 		receivers <- event.Provider
-		if len(receivers)+1 == cap(receivers) {
+		if len(receivers) == cap(receivers) {
 			done <- nil
 		}
-
 	})
 	defer unsubscribe()
 
@@ -195,7 +194,7 @@ func TestSendAddRequestDiffRegions(t *testing.T) {
 		t.Error("requests incomplete")
 	case <-done:
 		pp := supply.providerPeers[rootCid].Peers()
-		require.Equal(t, len(pp), 5)
+		require.Equal(t, len(pp), 4)
 		for i := 0; i < len(pp); i++ {
 			asiaNodes[pp[i]].VerifyFileTransferred(ctx, t, rootCid, origBytes)
 		}


### PR DESCRIPTION
Here we enable the grouping of Myel nodes within different preset and custom regions. This allows partitioning of the network to target the right providers.