### PR TITLE
feat: prep DAG for storage

### DIFF
--- a/cmd/hop/cli/cli.go
+++ b/cmd/hop/cli/cli.go
@@ -37,6 +37,7 @@ change in the future.
 			startCmd,
 			pingCmd,
 			addCmd,
+			statusCmd,
 			getCmd,
 		},
 		FlagSet: rootfs,

--- a/cmd/hop/cli/cli.go
+++ b/cmd/hop/cli/cli.go
@@ -38,6 +38,7 @@ change in the future.
 			pingCmd,
 			addCmd,
 			statusCmd,
+			commitCmd,
 			getCmd,
 		},
 		FlagSet: rootfs,

--- a/cmd/hop/cli/commit.go
+++ b/cmd/hop/cli/commit.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/myelnet/go-hop-exchange/node"
+	"github.com/peterbourgon/ff/v2/ffcli"
+)
+
+var commitCmd = &ffcli.Command{
+	Name:      "commit",
+	ShortHelp: "Commit the current index into a single dag",
+	LongHelp: strings.TrimSpace(`
+
+The 'hop commit' command creates a single DAG with the current index of staged DAGs. It optionally
+archives it into a CAR file for storage.
+
+`),
+	Exec: runCommit,
+}
+
+func runCommit(ctx context.Context, args []string) error {
+	c, cc, ctx, cancel := connect(ctx)
+	defer cancel()
+
+	crc := make(chan *node.CommitResult, 1)
+	cc.SetNotifyCallback(func(n node.Notify) {
+		if cr := n.CommitResult; cr != nil {
+			crc <- cr
+		}
+	})
+	go receive(ctx, cc, c)
+
+	cc.Commit(&node.CommitArgs{})
+	select {
+	case cr := <-crc:
+		if cr.Err != "" {
+			return errors.New(cr.Err)
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/cmd/hop/cli/status.go
+++ b/cmd/hop/cli/status.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/myelnet/go-hop-exchange/node"
+	"github.com/peterbourgon/ff/v2/ffcli"
+	"github.com/rs/zerolog/log"
+)
+
+var statusCmd = &ffcli.Command{
+	Name:      "status",
+	ShortHelp: "Show the working dag status",
+	LongHelp: strings.TrimSpace(`
+
+The 'hop status' command prints all the files that have been added to the blockstore. Files that have
+been chunked and staged in the blockstore but not yet committed into a Car to be pushed to the network.
+
+`),
+	Exec: runStatus,
+}
+
+func runStatus(ctx context.Context, args []string) error {
+	c, cc, ctx, cancel := connect(ctx)
+	defer cancel()
+
+	src := make(chan *node.StatusResult, 1)
+	cc.SetNotifyCallback(func(n node.Notify) {
+		if sr := n.StatusResult; sr != nil {
+			src <- sr
+		}
+	})
+	go receive(ctx, cc, c)
+
+	cc.Status(&node.StatusArgs{})
+	select {
+	case sr := <-src:
+		if sr.Err != "" {
+			return errors.New(sr.Err)
+		}
+		if sr.Output == "" {
+			log.Info().Msg("nothing to commit, workdag clean")
+			return nil
+		}
+		log.Info().Msg(fmt.Sprintf("\n%s", sr.Output))
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestExchangeDirect(t *testing.T) {
 	// Iterating a ton helps weed out false positives
-	for i := 0; i < 11; i++ {
+	for i := 0; i < 1; i++ {
 		t.Run(fmt.Sprintf("Try %v", i), func(t *testing.T) {
 			bgCtx := context.Background()
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestExchangeDirect(t *testing.T) {
 	// Iterating a ton helps weed out false positives
-	for i := 0; i < 1; i++ {
+	for i := 0; i < 11; i++ {
 		t.Run(fmt.Sprintf("Try %v", i), func(t *testing.T) {
 			bgCtx := context.Background()
 
@@ -59,6 +59,7 @@ func TestExchangeDirect(t *testing.T) {
 				settings := Settings{
 					Datastore:  n.Ds,
 					Blockstore: n.Bs,
+					MultiStore: n.Ms,
 					Host:       n.Host,
 					PubSub:     ps,
 					GraphSync:  n.Gs,
@@ -83,12 +84,18 @@ func TestExchangeDirect(t *testing.T) {
 
 			require.NoError(t, mn.ConnectAllButSelf())
 
-			link, origBytes := cnode.LoadUnixFSFileToStore(ctx, t, "/README.md")
+			link, storeID, origBytes := cnode.LoadFileToNewStore(ctx, t, "/README.md")
 			rootCid := link.(cidlink.Link).Cid
 
 			// In this test we expect the maximum of providers to receive the content
 			// that may not be the case in the real world
-			res, err := client.Dispatch(rootCid)
+			res, err := client.Supply().Dispatch(supply.Request{
+				PayloadCID: rootCid,
+				Size:       uint64(len(origBytes)),
+			},
+				supply.DispatchOptions{
+					StoreID: storeID,
+				})
 			require.NoError(t, err)
 
 			var records []supply.PRecord
@@ -101,13 +108,16 @@ func TestExchangeDirect(t *testing.T) {
 
 			// Gather and check all the recipients have a proper copy of the file
 			for _, r := range records {
-				pnodes[r.Provider].VerifyFileTransferred(ctx, t, rootCid, origBytes)
+				store, err := providers[r.Provider].Supply().GetStore(rootCid)
+				require.NoError(t, err)
+				pnodes[r.Provider].VerifyFileTransferred(ctx, t, store.DAG, rootCid, origBytes)
 			}
 
-			cnode.NukeBlockstore(ctx, t)
+			err = client.Supply().RemoveContent(rootCid)
+			require.NoError(t, err)
 
 			// Sanity check to make sure our client does not have a copy of our blocks
-			_, err = cnode.DAG.Get(ctx, rootCid)
+			_, err = client.Supply().GetStore(rootCid)
 			require.Error(t, err)
 
 			// Now we fetch it again from our providers
@@ -128,8 +138,10 @@ func TestExchangeDirect(t *testing.T) {
 				t.Fatal("failed to finish sync")
 			}
 
+			store, err := cnode.Ms.Get(session.StoreID())
+			require.NoError(t, err)
 			// And we verify we got the file back
-			cnode.VerifyFileTransferred(ctx, t, rootCid, origBytes)
+			cnode.VerifyFileTransferred(ctx, t, store.DAG, rootCid, origBytes)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/ipfs/go-path v0.0.9
 	github.com/ipfs/go-unixfs v0.2.4
+	github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d
 	github.com/ipld/go-ipld-prime v0.7.0
 	github.com/ipld/go-ipld-prime-proto v0.1.1
 	github.com/jpillora/backoff v1.0.0

--- a/node/hopn.go
+++ b/node/hopn.go
@@ -395,6 +395,18 @@ func (nd *node) Status(ctx context.Context, args *StatusArgs) {
 	})
 }
 
+// Commit packages multiple unix FS dags into one, kind of like a flat directory
+func (nd *node) Commit(ctx context.Context, args *CommitArgs) {
+	sendErr := func(err error) {
+		nd.send(Notify{
+			CommitResult: &CommitResult{
+				Err: err.Error(),
+			},
+		})
+	}
+	sendErr(errors.New("TODO"))
+}
+
 // Get sends a request for content with the given arguments. It also sends feedback to any open cli
 // connections
 func (nd *node) Get(ctx context.Context, args *GetArgs) {

--- a/node/message.go
+++ b/node/message.go
@@ -25,9 +25,14 @@ type AddArgs struct {
 	ChunkSize int
 }
 
-// StatusArgs get passes to the Status command
+// StatusArgs get passed to the Status command
 type StatusArgs struct {
 	Verbose bool
+}
+
+// CommitArgs are passed to the Commit command
+type CommitArgs struct {
+	Archive bool
 }
 
 // GetArgs get passed to the Get command
@@ -45,6 +50,7 @@ type Command struct {
 	Ping   *PingArgs
 	Add    *AddArgs
 	Status *StatusArgs
+	Commit *CommitArgs
 	Get    *GetArgs
 }
 
@@ -72,6 +78,12 @@ type StatusResult struct {
 	Err    string
 }
 
+// CommitResult gives us feedback on the result of the Commit operation
+type CommitResult struct {
+	DataCid string
+	Err     string
+}
+
 // GetResult gives us feedback on the result of the Get request
 type GetResult struct {
 	DealID          string
@@ -90,6 +102,7 @@ type Notify struct {
 	PingResult   *PingResult
 	AddResult    *AddResult
 	StatusResult *StatusResult
+	CommitResult *CommitResult
 	GetResult    *GetResult
 }
 
@@ -128,6 +141,10 @@ func (cs *CommandServer) GotMsg(ctx context.Context, cmd *Command) error {
 	}
 	if c := cmd.Status; c != nil {
 		cs.n.Status(ctx, c)
+		return nil
+	}
+	if c := cmd.Commit; c != nil {
+		cs.n.Commit(ctx, c)
 		return nil
 	}
 	if c := cmd.Get; c != nil {
@@ -199,6 +216,10 @@ func (cc *CommandClient) Add(args *AddArgs) {
 
 func (cc *CommandClient) Status(args *StatusArgs) {
 	cc.send(Command{Status: args})
+}
+
+func (cc *CommandClient) Commit(args *CommitArgs) {
+	cc.send(Command{Commit: args})
 }
 
 func (cc *CommandClient) Get(args *GetArgs) {

--- a/node/message.go
+++ b/node/message.go
@@ -25,6 +25,11 @@ type AddArgs struct {
 	ChunkSize int
 }
 
+// StatusArgs get passes to the Status command
+type StatusArgs struct {
+	Verbose bool
+}
+
 // GetArgs get passed to the Get command
 type GetArgs struct {
 	Cid     string
@@ -37,9 +42,10 @@ type GetArgs struct {
 
 // Command is a message sent from a client to the daemon
 type Command struct {
-	Ping *PingArgs
-	Add  *AddArgs
-	Get  *GetArgs
+	Ping   *PingArgs
+	Add    *AddArgs
+	Status *StatusArgs
+	Get    *GetArgs
 }
 
 // PingResult is sent in the notify message to give us the info we requested
@@ -60,6 +66,12 @@ type AddResult struct {
 	Err       string
 }
 
+// StatusResult gives us the result of status request to pring
+type StatusResult struct {
+	Output string
+	Err    string
+}
+
 // GetResult gives us feedback on the result of the Get request
 type GetResult struct {
 	DealID          string
@@ -75,18 +87,19 @@ type GetResult struct {
 
 // Notify is a message sent from the daemon to the client
 type Notify struct {
-	PingResult *PingResult
-	AddResult  *AddResult
-	GetResult  *GetResult
+	PingResult   *PingResult
+	AddResult    *AddResult
+	StatusResult *StatusResult
+	GetResult    *GetResult
 }
 
 // CommandServer receives commands on the daemon side and executes them
 type CommandServer struct {
-	n             IPFSNode             // the ipfs node we are controlling
+	n             *node                // the ipfs node we are controlling
 	sendNotifyMsg func(jsonMsg []byte) // send a notification message
 }
 
-func NewCommandServer(ipfs IPFSNode, sendNotifyMsg func(b []byte)) *CommandServer {
+func NewCommandServer(ipfs *node, sendNotifyMsg func(b []byte)) *CommandServer {
 	return &CommandServer{
 		n:             ipfs,
 		sendNotifyMsg: sendNotifyMsg,
@@ -111,6 +124,10 @@ func (cs *CommandServer) GotMsg(ctx context.Context, cmd *Command) error {
 	}
 	if c := cmd.Add; c != nil {
 		cs.n.Add(ctx, c)
+		return nil
+	}
+	if c := cmd.Status; c != nil {
+		cs.n.Status(ctx, c)
 		return nil
 	}
 	if c := cmd.Get; c != nil {
@@ -178,6 +195,10 @@ func (cc *CommandClient) Ping(addr string) {
 
 func (cc *CommandClient) Add(args *AddArgs) {
 	cc.send(Command{Add: args})
+}
+
+func (cc *CommandClient) Status(args *StatusArgs) {
+	cc.send(Command{Status: args})
 }
 
 func (cc *CommandClient) Get(args *GetArgs) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -26,6 +26,7 @@ func newTestNode(ctx context.Context, mn mocknet.Mocknet, t *testing.T) *node {
 	nd := &node{}
 	nd.ds = tn.Ds
 	nd.bs = tn.Bs
+	nd.ms = tn.Ms
 	nd.dag = tn.DAG
 	nd.host = tn.Host
 	nd.gs = tn.Gs
@@ -35,6 +36,7 @@ func newTestNode(ctx context.Context, mn mocknet.Mocknet, t *testing.T) *node {
 	settings := hop.Settings{
 		Datastore:  nd.ds,
 		Blockstore: nd.bs,
+		MultiStore: nd.ms,
 		Host:       nd.host,
 		PubSub:     nd.ps,
 		GraphSync:  nd.gs,

--- a/node/workdag.go
+++ b/node/workdag.go
@@ -1,0 +1,220 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/filecoin-project/go-multistore"
+	cid "github.com/ipfs/go-cid"
+	chunk "github.com/ipfs/go-ipfs-chunker"
+	files "github.com/ipfs/go-ipfs-files"
+	ipldformat "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-unixfs/importer/balanced"
+	"github.com/ipfs/go-unixfs/importer/helpers"
+	"github.com/ipld/go-car"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/myelnet/go-hop-exchange"
+)
+
+var (
+	// ErrEntryNotFound is returned by Index.Entry, if an entry is not found.
+	ErrEntryNotFound = errors.New("entry not found")
+)
+
+// Workdag represents any local content that hasn't been committed into a car file yet.
+type Workdag struct {
+	store *multistore.Store
+	index *Index
+}
+
+// AddOptions describes how an add operation should be performed
+type AddOptions struct {
+	// Path is the exact filepath to a the file or directory to be added.
+	Path string
+	// ChunkSize is size by which to chunk the content when adding a file.
+	ChunkSize int64
+}
+
+// Add adds the file contents of a file in the workdag
+func (w *Workdag) Add(ctx context.Context, opts AddOptions) (cid.Cid, error) {
+	link, err := w.doAdd(ctx, opts)
+	if err != nil {
+		return cid.Undef, err
+	}
+	root := link.(cidlink.Link).Cid
+	return root, nil
+}
+
+func (w *Workdag) doAdd(ctx context.Context, opts AddOptions) (ipld.Link, error) {
+	st, err := os.Stat(opts.Path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := files.NewSerialFile(opts.Path, false, st)
+	if err != nil {
+		return nil, err
+	}
+
+	switch f := file.(type) {
+	case files.Directory:
+		return w.doAddDir(ctx, f, opts)
+	case files.File:
+		return w.doAddFile(ctx, f, opts)
+	default:
+		return nil, fmt.Errorf("unknown file type")
+	}
+}
+
+func (w *Workdag) doAddFile(ctx context.Context, f files.File, opts AddOptions) (ipld.Link, error) {
+	bufferedDS := ipldformat.NewBufferedDAG(ctx, w.store.DAG)
+
+	prefix, err := merkledag.PrefixForCidVersion(1)
+	if err != nil {
+		return nil, err
+	}
+	prefix.MhType = DefaultHashFunction
+
+	params := helpers.DagBuilderParams{
+		Maxlinks:   unixfsLinksPerLevel,
+		RawLeaves:  true,
+		CidBuilder: prefix,
+		Dagserv:    bufferedDS,
+	}
+
+	db, err := params.New(chunk.NewSizeSplitter(f, opts.ChunkSize))
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := balanced.Layout(db)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bufferedDS.Commit()
+	if err != nil {
+		return nil, err
+	}
+	e, err := w.index.Entry(opts.Path)
+	if errors.Is(err, ErrEntryNotFound) {
+		e = w.index.Add(opts.Path)
+	} else if err != nil {
+		return nil, err
+	}
+	e.Cid = n.Cid()
+	e.Size, err = f.Size()
+	if err != nil {
+		return nil, err
+	}
+
+	return cidlink.Link{Cid: n.Cid()}, nil
+
+}
+
+func (w *Workdag) doAddDir(ctx context.Context, dir files.Directory, opts AddOptions) (ipld.Link, error) {
+	return nil, fmt.Errorf("TODO")
+}
+
+// Status represents our staged files, the key is a string path
+type Status map[string]cid.Cid
+
+func (s Status) String() string {
+	buf := bytes.NewBuffer(nil)
+	for path, c := range s {
+		fmt.Fprintf(buf, "%s %s\n", c, path)
+	}
+
+	return buf.String()
+}
+
+// Status returns the current Status
+func (w *Workdag) Status() (Status, error) {
+	s := make(Status)
+	for _, e := range w.index.Entries {
+		s[e.Name] = e.Cid
+	}
+	return s, nil
+}
+
+// CommitOptions might be useful later to add authorship
+type CommitOptions struct {
+}
+
+// Commit stores the current contents of the index in a new car and loads it in the blockstore
+func (w *Workdag) Commit(ctx context.Context, opts CommitOptions) ([]cid.Cid, error) {
+	buf := new(bytes.Buffer)
+
+	var dags []car.Dag
+	for _, e := range w.index.Entries {
+		dags = append(dags, car.Dag{Root: e.Cid, Selector: hop.AllSelector()})
+	}
+
+	sc := car.NewSelectiveCar(ctx, w.store.Bstore, dags)
+	if err := sc.Write(buf); err != nil {
+		return nil, err
+	}
+	ch, err := car.LoadCar(w.store.Bstore, buf)
+	if err != nil {
+		return nil, err
+	}
+	return ch.Roots, nil
+}
+
+// Index contains the information about which objects are currently checked out
+// in the workdag, having information about the working files.
+type Index struct {
+	// Entries collection of entries represented by this Index. The order of
+	// this collection is not guaranteed
+	Entries []*Entry
+}
+
+// Add creates a new Entry and returns it. The caller should first check that
+// another entry with the same path does not exist.
+func (i *Index) Add(path string) *Entry {
+	e := &Entry{
+		Name: path,
+	}
+
+	i.Entries = append(i.Entries, e)
+	return e
+}
+
+// Entry returns the entry that match the given path, if any.
+func (i *Index) Entry(path string) (*Entry, error) {
+	for _, e := range i.Entries {
+		if e.Name == path {
+			return e, nil
+		}
+	}
+
+	return nil, ErrEntryNotFound
+}
+
+// Remove remove the entry that match the give path and returns deleted entry.
+func (i *Index) Remove(path string) (*Entry, error) {
+	path = filepath.ToSlash(path)
+	for index, e := range i.Entries {
+		if e.Name == path {
+			i.Entries = append(i.Entries[:index], i.Entries[index+1:]...)
+			return e, nil
+		}
+	}
+
+	return nil, ErrEntryNotFound
+}
+
+// Entry represents the merkle root of a single file
+type Entry struct {
+	// Cid is the content id of the represented
+	Cid cid.Cid
+	// Name is the entry path
+	Name string
+	// Size is the original file size
+	Size int64
+}

--- a/node/workdag_test.go
+++ b/node/workdag_test.go
@@ -48,24 +48,27 @@ func TestWorkdag(t *testing.T) {
 
 	filepaths := genTestFiles(t)
 
-	sidx := ms.Next()
-	s, err := ms.Get(sidx)
+	wd, err := NewWorkdag(ms, ds)
 	require.NoError(t, err)
 
-	wd := &Workdag{
-		store: s,
-		index: &Index{},
-	}
-
-	for _, p := range filepaths {
-		_, err := wd.Add(ctx, AddOptions{Path: p, ChunkSize: int64(1 << 10)})
+	for i := 0; i < 6; i++ {
+		_, err := wd.Add(ctx, AddOptions{Path: filepaths[i], ChunkSize: int64(1 << 10)})
 		require.NoError(t, err)
 
 	}
 
 	status, err := wd.Status()
 	require.NoError(t, err)
-	require.Equal(t, len(filepaths), len(status))
+	require.Equal(t, 6, len(status))
+
+	// Should handle new instance
+	wd, err = NewWorkdag(ms, ds)
+	require.NoError(t, err)
+
+	for i := 6; i < 8; i++ {
+		_, err := wd.Add(ctx, AddOptions{Path: filepaths[i], ChunkSize: int64(1 << 10)})
+		require.NoError(t, err)
+	}
 
 	roots, err := wd.Commit(ctx, CommitOptions{})
 	require.NoError(t, err)

--- a/node/workdag_test.go
+++ b/node/workdag_test.go
@@ -1,0 +1,73 @@
+package node
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/filecoin-project/go-multistore"
+	"github.com/ipfs/go-datastore"
+	dss "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func genTestFiles(t *testing.T) []string {
+	dir := t.TempDir()
+
+	testInputs := map[string]string{
+		"1": "Two roads diverged in a yellow wood,\n",
+		"2": "And sorry I could not travel both\n",
+		"3": "And be one traveler, long I stood\n",
+		"4": "And looked down one as far as I could\n",
+		"5": "To where it bent in the undergrowth;\n",
+		"6": "Then took the other, as just as fair,\n",
+		"7": "And having perhaps the better claim,\n",
+		"8": "Because it was grassy and wanted wear;\n",
+	}
+
+	paths := make([]string, 0, len(testInputs))
+
+	for p, c := range testInputs {
+		path := filepath.Join(dir, p)
+
+		if err := ioutil.WriteFile(path, []byte(c), 0666); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func TestWorkdag(t *testing.T) {
+	ctx := context.Background()
+
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
+	ms, err := multistore.NewMultiDstore(ds)
+	require.NoError(t, err)
+
+	filepaths := genTestFiles(t)
+
+	sidx := ms.Next()
+	s, err := ms.Get(sidx)
+	require.NoError(t, err)
+
+	wd := &Workdag{
+		store: s,
+		index: &Index{},
+	}
+
+	for _, p := range filepaths {
+		_, err := wd.Add(ctx, AddOptions{Path: p, ChunkSize: int64(1 << 10)})
+		require.NoError(t, err)
+
+	}
+
+	status, err := wd.Status()
+	require.NoError(t, err)
+	require.Equal(t, len(filepaths), len(status))
+
+	roots, err := wd.Commit(ctx, CommitOptions{})
+	require.NoError(t, err)
+	require.Equal(t, len(filepaths), len(roots))
+}

--- a/options.go
+++ b/options.go
@@ -13,6 +13,7 @@ import (
 	dtfimpl "github.com/filecoin-project/go-data-transfer/impl"
 	dtnet "github.com/filecoin-project/go-data-transfer/network"
 	gstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
+	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-storedcounter"
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -37,6 +38,7 @@ import (
 type Settings struct {
 	Datastore           datastore.Batching
 	Blockstore          blockstore.Blockstore
+	MultiStore          *multistore.MultiStore
 	Host                host.Host
 	PubSub              *pubsub.PubSub
 	GraphSync           graphsync.GraphExchange

--- a/retrieval/client/fsm.go
+++ b/retrieval/client/fsm.go
@@ -225,7 +225,11 @@ var FSMEvents = fsm.Events{
 		FromMany(paymentChannelCreationStates...).ToJustRecord().
 		FromMany(deal.StatusSendFunds, deal.StatusFundsNeeded).ToJustRecord().
 		From(deal.StatusFundsNeededLastPayment).To(deal.StatusSendFundsLastPayment).
-		From(deal.StatusClientWaitingForLastBlocks).To(deal.StatusCompleted).
+		FromMany(
+			deal.StatusClientWaitingForLastBlocks,
+			// Should fix err: Invalid transition in queue, state `21`, event `16`
+			deal.StatusCheckComplete,
+		).To(deal.StatusCompleted).
 		Action(func(ds *deal.ClientState) error {
 			ds.AllBlocksReceived = true
 			return nil

--- a/retrieval/environments.go
+++ b/retrieval/environments.go
@@ -9,6 +9,7 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-multistore"
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
@@ -137,7 +138,12 @@ func (pve *providerValidationEnvironment) BeginTracking(pds deal.ProviderState) 
 	return pve.p.stateMachines.Send(pds.Identifier(), provider.EventOpen)
 }
 
-// NextStoreID allocates a store for this deal
+// GetStoreID finds a store where our content is currently
+func (pve *providerValidationEnvironment) GetStoreID(c cid.Cid) (multistore.StoreID, error) {
+	return pve.p.storeIDGetter.GetStoreID(c)
+}
+
+// NextStoreID allocates a store for this deal TODO: do we still need this?
 func (pve *providerValidationEnvironment) NextStoreID() (multistore.StoreID, error) {
 	storeID := pve.p.multiStore.Next()
 	_, err := pve.p.multiStore.Get(storeID)

--- a/retrieval/provider/fsm.go
+++ b/retrieval/provider/fsm.go
@@ -160,13 +160,9 @@ type DealEnvironment interface {
 	CloseDataTransfer(context.Context, datatransfer.ChannelID) error
 }
 
-// TrackTransfer resumes a deal so we can start sending data
+// TrackTransfer keeps track of a transfer during revalidation
 func TrackTransfer(ctx fsm.Context, environment DealEnvironment, ds deal.ProviderState) error {
 	err := environment.TrackTransfer(ds)
-	if err != nil {
-		return ctx.Trigger(EventDataTransferError, err)
-	}
-	err = environment.ResumeDataTransfer(ctx.Context(), ds.ChannelID)
 	if err != nil {
 		return ctx.Trigger(EventDataTransferError, err)
 	}

--- a/supply/manifest.go
+++ b/supply/manifest.go
@@ -2,9 +2,14 @@ package supply
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-multistore"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipld/go-ipld-prime"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
@@ -21,11 +26,95 @@ type Manifest struct {
 	h host.Host
 	// Some transfers may require payment in which case we will need a new instance of the data transfer manager
 	dt datatransfer.Manager
+	// Datastore for storing the manifest
+	ds datastore.Batching
+	// MultiStore for creating independent stores for each new content
+	ms *multistore.MultiStore
+}
+
+const (
+	// KStoreID is the local store ID where that content is stored
+	KStoreID = "store"
+	// KSize is the full content size
+	KSize = "size"
+)
+
+// ContentRecord is a map of labels associated with a content ID
+// lind of like a mini database for that content activity
+type ContentRecord struct {
+	Labels map[string]string
 }
 
 // NewManifest creates a new Manifest instance
-func NewManifest(h host.Host, dt datatransfer.Manager) *Manifest {
-	return &Manifest{h, dt}
+func NewManifest(
+	h host.Host,
+	dt datatransfer.Manager,
+	ds datastore.Batching,
+	ms *multistore.MultiStore,
+) *Manifest {
+	return &Manifest{
+		h:  h,
+		dt: dt,
+		ds: namespace.Wrap(ds, datastore.NewKey("/supply")),
+		ms: ms,
+	}
+}
+
+// PutRecord creates a new record for a given content ID
+func (m *Manifest) PutRecord(id cid.Cid, r *ContentRecord) error {
+	rec, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	return m.ds.Put(datastore.NewKey(id.String()), rec)
+}
+
+// GetRecord returns a record for a given content ID
+func (m *Manifest) GetRecord(id cid.Cid) (*ContentRecord, error) {
+	r, err := m.ds.Get(datastore.NewKey(id.String()))
+	if err != nil {
+		return nil, err
+	}
+
+	var rec ContentRecord
+	if err := json.Unmarshal(r, &rec); err != nil {
+		return nil, err
+	}
+
+	return &rec, nil
+}
+
+// AddLabel adds a label to a ContentRecord
+func (m *Manifest) AddLabel(id cid.Cid, key, value string) error {
+	dsk := datastore.NewKey(id.String())
+
+	r, err := m.ds.Get(dsk)
+	if err != nil {
+		return err
+	}
+
+	var rec ContentRecord
+	if err := json.Unmarshal(r, &rec); err != nil {
+		return err
+	}
+
+	rec.Labels[key] = value
+
+	r, err = json.Marshal(&rec)
+	if err != nil {
+		return err
+	}
+
+	return m.ds.Put(dsk, r)
+}
+
+// RemoveRecord removes a record entirely from our manifest
+func (m *Manifest) RemoveRecord(id cid.Cid) error {
+	if err := m.ds.Delete(datastore.NewKey(id.String())); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleRequest and decide whether to add the block to our supply or not
@@ -40,6 +129,17 @@ func (m *Manifest) HandleRequest(stream RequestStreamer) {
 	// TODO: run custom logic to validate the presence of a storage deal for this block
 	// we may need to request deal info in the message
 	// + check if we have room to store it
+
+	// Create a new store to receive our new blocks
+	// It will be automatically picked up in the TransportConfigurer
+	storeID := m.ms.Next()
+	err = m.PutRecord(req.PayloadCID, &ContentRecord{Labels: map[string]string{
+		KStoreID: fmt.Sprintf("%d", storeID),
+		KSize:    fmt.Sprintf("%d", req.Size),
+	}})
+	if err != nil {
+		return
+	}
 	if err := m.SyncBlocks(context.Background(), req, stream.OtherPeer()); err != nil {
 		fmt.Println("Unable to add new block to our supply", err)
 		return

--- a/supply/manifest_test.go
+++ b/supply/manifest_test.go
@@ -55,7 +55,7 @@ func TestHandleRequest(t *testing.T) {
 
 	// n2 is our provider and received a request from n1 (mocked in this test)
 	// it calls HandleAddRequest to maybe retrieve it from the client
-	manifest := NewManifest(n2.Host, n2.Dt)
+	manifest := NewManifest(n2.Host, n2.Dt, n2.Ds, n2.Ms)
 	stream := &mockRequestStream{
 		req: Request{
 			PayloadCID: rootCid,
@@ -68,5 +68,5 @@ func TestHandleRequest(t *testing.T) {
 	manifest.HandleRequest(stream)
 
 	// Now we check if we have received the blocks
-	n2.VerifyFileTransferred(bgCtx, t, rootCid, origBytes)
+	n2.VerifyFileTransferred(bgCtx, t, n2.DAG, rootCid, origBytes)
 }

--- a/supply/supply.go
+++ b/supply/supply.go
@@ -2,9 +2,13 @@ package supply
 
 import (
 	"fmt"
+	"strconv"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-multistore"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/host"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
@@ -15,8 +19,17 @@ var ErrNoPeers = fmt.Errorf("no peers available for supply")
 // Manager exposes methods to manage the blocks we can serve as a provider
 type Manager interface {
 	// Dispatch a Request to n providers to cache our content, may expose the n as a param if need be
-	Dispatch(Request) (*Response, error)
+	Dispatch(Request, DispatchOptions) (*Response, error)
 	ProviderPeersForContent(cid.Cid) ([]peer.ID, error)
+	GetStoreID(cid.Cid) (multistore.StoreID, error)
+	GetStore(cid.Cid) (*multistore.Store, error)
+	RemoveContent(cid.Cid) error
+}
+
+// DispatchOptions encapsulates some options about how we want our content to be
+// dispatched
+type DispatchOptions struct {
+	StoreID multistore.StoreID
 }
 
 // Supply keeps track of the content we store and provide on the network
@@ -24,6 +37,7 @@ type Manager interface {
 type Supply struct {
 	h       host.Host
 	dt      datatransfer.Manager
+	ms      *multistore.MultiStore
 	net     *Network
 	man     *Manifest
 	regions []Region
@@ -39,19 +53,25 @@ type PRecord struct {
 func New(
 	h host.Host,
 	dt datatransfer.Manager,
+	ds datastore.Batching,
+	ms *multistore.MultiStore,
 	regions []Region,
 ) *Supply {
 	// We wrap it all in our Supply object
 	s := &Supply{
 		h:       h,
 		dt:      dt,
+		ms:      ms,
 		regions: regions,
 	}
 
 	// TODO: validate AddRequest
 	s.dt.RegisterVoucherType(&Request{}, &UnifiedRequestValidator{})
 
-	s.man = NewManifest(h, dt)
+	// switch store based on voucher fields
+	s.dt.RegisterTransportConfigurer(&Request{}, TransportConfigurer(s))
+
+	s.man = NewManifest(h, dt, ds, ms)
 	// Connect to incoming supply messages form peers
 	s.net = NewNetwork(h, regions)
 	// Set the manifest to handle our messages
@@ -66,7 +86,16 @@ func (s *Supply) ProviderPeersForContent(c cid.Cid) ([]peer.ID, error) {
 }
 
 // Dispatch requests to the network until we have propagated the content to enough peers
-func (s *Supply) Dispatch(r Request) (*Response, error) {
+// it also tells the exchange we are providing this content in our supply
+func (s *Supply) Dispatch(r Request, opts DispatchOptions) (*Response, error) {
+	// Store a record of the content in our supply
+	err := s.man.PutRecord(r.PayloadCID, &ContentRecord{Labels: map[string]string{
+		KStoreID: fmt.Sprintf("%d", opts.StoreID),
+		KSize:    fmt.Sprintf("%d", r.Size),
+	}})
+	if err != nil {
+		return nil, err
+	}
 	res := &Response{
 		recordChan: make(chan PRecord),
 	}
@@ -142,6 +171,81 @@ func (s *Supply) sendAllRequests(r Request, peers []peer.ID) {
 		if err != nil {
 			fmt.Println("Unable to send addRequest:", err)
 			continue
+		}
+	}
+}
+
+// GetStoreID returns the StoreID of the store which has the content
+func (s *Supply) GetStoreID(id cid.Cid) (multistore.StoreID, error) {
+	rec, err := s.man.GetRecord(id)
+	if err != nil {
+		return 0, err
+	}
+	sid, ok := rec.Labels[KStoreID]
+	if !ok {
+		return 0, fmt.Errorf("storeID not found")
+	}
+	storeID, err := strconv.ParseUint(sid, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return multistore.StoreID(storeID), nil
+}
+
+// GetStore returns the correct multistore associated with a data CID
+func (s *Supply) GetStore(id cid.Cid) (*multistore.Store, error) {
+	storeID, err := s.GetStoreID(id)
+	if err != nil {
+		return nil, err
+	}
+	store, err := s.ms.Get(storeID)
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// RemoveContent removes all content linked to a root CID by completed dropping the store
+func (s *Supply) RemoveContent(root cid.Cid) error {
+	storeID, err := s.GetStoreID(root)
+	if err != nil {
+		return err
+	}
+	err = s.ms.Delete(storeID)
+	if err != nil {
+		return err
+	}
+	return s.man.RemoveRecord(root)
+}
+
+// StoreConfigurableTransport defines the methods needed to
+// configure a data transfer transport use a unique store for a given request
+type StoreConfigurableTransport interface {
+	UseStore(datatransfer.ChannelID, ipld.Loader, ipld.Storer) error
+}
+
+// TransportConfigurer configurers the graphsync transport to use a custom blockstore per content
+func TransportConfigurer(s *Supply) datatransfer.TransportConfigurer {
+	return func(channelID datatransfer.ChannelID, voucher datatransfer.Voucher, transport datatransfer.Transport) {
+		warn := func(err error) {
+			fmt.Println("attempting to configure data store:", err)
+		}
+		request, ok := voucher.(*Request)
+		if !ok {
+			return
+		}
+		gsTransport, ok := transport.(StoreConfigurableTransport)
+		if !ok {
+			return
+		}
+		store, err := s.GetStore(request.PayloadCID)
+		if err != nil {
+			warn(err)
+			return
+		}
+		err = gsTransport.UseStore(channelID, store.Loader, store.Storer)
+		if err != nil {
+			warn(err)
 		}
 	}
 }


### PR DESCRIPTION
Here we introduce a new workflow inspired from git:
Once can use the cli to add multiple files to the 'workdag' and commit them into a single archive for storage. This makes it easier to storing multiple files onto the network. Further we enforce independent stores for each 'workdag'.